### PR TITLE
Add JWT auth middleware and secure routes

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,23 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = function authenticateToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader) {
+    return res.status(401).json({ erro: 'Token n\u00e3o fornecido' });
+  }
+
+  const parts = authHeader.split(' ');
+  if (parts.length !== 2 || parts[0] !== 'Bearer') {
+    return res.status(401).json({ erro: 'Token malformado' });
+  }
+
+  const token = parts[1];
+
+  jwt.verify(token, process.env.JWT_SECRET, (err, decoded) => {
+    if (err) {
+      return res.status(401).json({ erro: 'Token inv\u00e1lido' });
+    }
+    req.user = decoded;
+    next();
+  });
+};

--- a/routes/enderecoRoutes.js
+++ b/routes/enderecoRoutes.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const enderecoController = require('../controllers/enderecoController');
+const authenticateToken = require('../middleware/auth');
 
 // 🔍 GET - Listar todos os endereços
 router.get('/', enderecoController.listarEndereco);
@@ -9,10 +10,10 @@ router.get('/', enderecoController.listarEndereco);
 router.post('/', enderecoController.criarEndereco);
 
 // ✏️ PUT - Atualizar endereço existente
-router.put('/:id', enderecoController.atualizarEndereco);
+router.put('/:id', authenticateToken, enderecoController.atualizarEndereco);
 
 // 🗑️ DELETE - Remover endereço
-router.delete('/:id', enderecoController.deletarEndereco);
+router.delete('/:id', authenticateToken, enderecoController.deletarEndereco);
 
 // 🔍 GET - Listar endereços por usuário
 router.get('/usuario/:id_usuario', enderecoController.listarEnderecoPorUsuario);

--- a/routes/produtosRoutes.js
+++ b/routes/produtosRoutes.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const produtosController = require('../controllers/produtosController');
+const authenticateToken = require('../middleware/auth');
 
 // GET todos os produtos
 router.get('/', produtosController.listarProdutos);
@@ -9,9 +10,9 @@ router.get('/', produtosController.listarProdutos);
 router.post('/', produtosController.criarProduto);
 
 // PUT atualização
-router.put('/:id', produtosController.atualizarProduto);
+router.put('/:id', authenticateToken, produtosController.atualizarProduto);
 
 // DELETE produto
-router.delete('/:id', produtosController.removerProduto);
+router.delete('/:id', authenticateToken, produtosController.removerProduto);
 
 module.exports = router;

--- a/routes/usuariosRoutes.js
+++ b/routes/usuariosRoutes.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const usuariosController = require('../controllers/usuariosController');
+const authenticateToken = require('../middleware/auth');
 
 
 // Endpoint para login do usuário
@@ -10,9 +11,9 @@ router.get('/',  usuariosController.listarUsuarios);
 // Cria um novo usuário
 router.post('/',  usuariosController.criarUsuario);
 // Atualiza um usuário existente
-router.put('/:id',  usuariosController.atualizarUsuario);
+router.put('/:id', authenticateToken, usuariosController.atualizarUsuario);
 // Remove um usuário
-router.delete('/:id',  usuariosController.removerUsuario);
+router.delete('/:id', authenticateToken, usuariosController.removerUsuario);
 // Atualiza o nível de acesso de um usuário
-router.put('/:id/nivel', usuariosController.atualizarNivelAcesso);
+router.put('/:id/nivel', authenticateToken, usuariosController.atualizarNivelAcesso);
 module.exports = router;

--- a/tests/endereco.test.js
+++ b/tests/endereco.test.js
@@ -1,4 +1,5 @@
 const request = require('supertest');
+const jwt = require('jsonwebtoken');
 
 jest.mock('../db');
 const db = require('../db');
@@ -35,7 +36,11 @@ describe('Enderecos endpoints', () => {
   test('delete address successfully', async () => {
     db.query.mockResolvedValueOnce({ rowCount: 1 });
 
-    const res = await request(app).delete('/enderecos/1');
+    const token = jwt.sign({}, process.env.JWT_SECRET || 'secret');
+
+    const res = await request(app)
+      .delete('/enderecos/1')
+      .set('Authorization', `Bearer ${token}`);
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ mensagem: 'Endere\u00e7o exclu\u00eddo com sucesso.' });

--- a/tests/produtos.test.js
+++ b/tests/produtos.test.js
@@ -1,4 +1,5 @@
 const request = require('supertest');
+const jwt = require('jsonwebtoken');
 
 jest.mock('../db');
 const db = require('../db');
@@ -36,7 +37,11 @@ describe('Produtos endpoints', () => {
   test('delete product successfully', async () => {
     db.query.mockResolvedValueOnce({ rowCount: 1 });
 
-    const res = await request(app).delete('/produtos/123');
+    const token = jwt.sign({}, process.env.JWT_SECRET || 'secret');
+
+    const res = await request(app)
+      .delete('/produtos/123')
+      .set('Authorization', `Bearer ${token}`);
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ mensagem: 'Produto removido com sucesso' });


### PR DESCRIPTION
## Summary
- implement JWT auth middleware
- secure update/delete product, address and user routes
- update tests to provide auth tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f5521501c832daa1133b7755a3290