### PR TITLE
Add basic input validation

### DIFF
--- a/middleware/validate.js
+++ b/middleware/validate.js
@@ -1,0 +1,27 @@
+function validate(schema) {
+  return (req, res, next) => {
+    const errors = [];
+    for (const field in schema) {
+      const rules = schema[field];
+      const value = req.body[field];
+      if (rules.required && (value === undefined || value === null || value === '')) {
+        errors.push(`${field} is required`);
+        continue;
+      }
+      if (value !== undefined && value !== null && value !== '') {
+        if (rules.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(value))) {
+          errors.push(`${field} must be a valid email`);
+        }
+        if (rules.number && isNaN(Number(value))) {
+          errors.push(`${field} must be a number`);
+        }
+      }
+    }
+    if (errors.length > 0) {
+      return res.status(400).json({ errors });
+    }
+    next();
+  };
+}
+
+module.exports = validate;

--- a/routes/enderecoRoutes.js
+++ b/routes/enderecoRoutes.js
@@ -2,15 +2,17 @@ const express = require('express');
 const router = express.Router();
 const enderecoController = require('../controllers/enderecoController');
 const authenticateToken = require('../middleware/auth');
+const validate = require('../middleware/validate');
+const enderecoSchema = require('../validators/enderecoValidator');
 
 // 🔍 GET - Listar todos os endereços
 router.get('/', enderecoController.listarEndereco);
 
 // ➕ POST - Criar novo endereço
-router.post('/', enderecoController.criarEndereco);
+router.post('/', validate(enderecoSchema.create), enderecoController.criarEndereco);
 
 // ✏️ PUT - Atualizar endereço existente
-router.put('/:id', authenticateToken, enderecoController.atualizarEndereco);
+router.put('/:id', authenticateToken, validate(enderecoSchema.update), enderecoController.atualizarEndereco);
 
 // 🗑️ DELETE - Remover endereço
 router.delete('/:id', authenticateToken, enderecoController.deletarEndereco);

--- a/routes/produtosRoutes.js
+++ b/routes/produtosRoutes.js
@@ -2,15 +2,17 @@ const express = require('express');
 const router = express.Router();
 const produtosController = require('../controllers/produtosController');
 const authenticateToken = require('../middleware/auth');
+const validate = require('../middleware/validate');
+const produtoSchema = require('../validators/produtoValidator');
 
 // GET todos os produtos
 router.get('/', produtosController.listarProdutos);
 
 // POST novo produto
-router.post('/', produtosController.criarProduto);
+router.post('/', validate(produtoSchema.create), produtosController.criarProduto);
 
 // PUT atualização
-router.put('/:id', authenticateToken, produtosController.atualizarProduto);
+router.put('/:id', authenticateToken, validate(produtoSchema.update), produtosController.atualizarProduto);
 
 // DELETE produto
 router.delete('/:id', authenticateToken, produtosController.removerProduto);

--- a/routes/usuariosRoutes.js
+++ b/routes/usuariosRoutes.js
@@ -2,14 +2,16 @@ const express = require('express');
 const router = express.Router();
 const usuariosController = require('../controllers/usuariosController');
 const authenticateToken = require('../middleware/auth');
+const validate = require('../middleware/validate');
+const userSchema = require('../validators/userValidator');
 
 
 // Endpoint para login do usuário
-router.post('/login', usuariosController.loginUsuario);
+router.post('/login', validate(userSchema.login), usuariosController.loginUsuario);
 // Lista todos os usuários
 router.get('/',  usuariosController.listarUsuarios);
 // Cria um novo usuário
-router.post('/',  usuariosController.criarUsuario);
+router.post('/', validate(userSchema.register), usuariosController.criarUsuario);
 // Atualiza um usuário existente
 router.put('/:id', authenticateToken, usuariosController.atualizarUsuario);
 // Remove um usuário

--- a/validators/enderecoValidator.js
+++ b/validators/enderecoValidator.js
@@ -1,0 +1,19 @@
+module.exports = {
+  create: {
+    id_usuario: { required: true },
+    rua: { required: true },
+    numero: { required: true },
+    bairro: { required: true },
+    cidade: { required: true },
+    estado: { required: true },
+    cep: { required: true }
+  },
+  update: {
+    rua: { required: true },
+    numero: { required: true },
+    bairro: { required: true },
+    cidade: { required: true },
+    estado: { required: true },
+    cep: { required: true }
+  }
+};

--- a/validators/produtoValidator.js
+++ b/validators/produtoValidator.js
@@ -1,0 +1,12 @@
+module.exports = {
+  create: {
+    codigo: { required: true },
+    nome: { required: true },
+    preco: { required: true, number: true }
+  },
+  update: {
+    codigo: { required: true },
+    nome: { required: true },
+    preco: { required: true, number: true }
+  }
+};

--- a/validators/userValidator.js
+++ b/validators/userValidator.js
@@ -1,0 +1,11 @@
+module.exports = {
+  register: {
+    nome_completo: { required: true },
+    email: { required: true, email: true },
+    senha: { required: true }
+  },
+  login: {
+    email: { required: true, email: true },
+    senha: { required: true }
+  }
+};


### PR DESCRIPTION
## Summary
- add a lightweight validation middleware
- define validation schemas for users, products and addresses
- enforce validation on registration, login, product and address routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f56bd0f7c832dbdf2b8ee4c88ae72